### PR TITLE
Add pkgdown config

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,10 @@
+reference:
+- title: "analysis-runner"
+  desc: >
+    Functions related to analysis-runner (https://github.com/populationgenomics/analysis-runner)
+- contents:
+  - bucket_path
+  - output_path
+- title: "Others"
+- contents:
+  - mkdir


### PR DESCRIPTION
Adding a config to set up pkgdown (https://pkgdown.r-lib.org/index.html). This file will generate a reference page listing all functions used in the package - see e.g. https://pkgdown.r-lib.org/reference/index.html